### PR TITLE
Refactor themes

### DIFF
--- a/public/icons/chevdown.svg
+++ b/public/icons/chevdown.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+</svg>

--- a/public/icons/chevup.svg
+++ b/public/icons/chevup.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5" />
+</svg>

--- a/src/app/_components/categoryList.tsx
+++ b/src/app/_components/categoryList.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { ThemeContext } from "../_providers/theme-provider";
 import { useContext } from "react";
-import { themeGen, pagePadding } from "../_utils";
+import { pagePadding } from "../_utils";
 import { CategoryTile, ListHeader } from "./index";
 import { FullCategory } from "../_types";
 
@@ -14,12 +14,12 @@ export default function CategoryList(props: CategoryListProps) {
   const { appTheme } = useContext(ThemeContext);
   return (
     <div
-      className={`flex flex-col ${themeGen(
-        appTheme
-      )} ${pagePadding()} min-h-screen`}
+      className={`flex flex-col bg-${appTheme}-bodyBg text-${appTheme}-text border-${appTheme}-border ${pagePadding()} min-h-screen`}
     >
       <ListHeader title={"Product Categories"} />
-      <div className={`grid grid-cols-3 text-xl gap-6 gap-y-8 grid-auto-rows`}>
+      <div
+        className={`grid grid-cols-3 text-xl gap-10 gap-y-8 grid-auto-rows mt-4`}
+      >
         {categories
           .sort((a, b) => {
             const nameA = a.name.toUpperCase();

--- a/src/app/_components/categoryTile.tsx
+++ b/src/app/_components/categoryTile.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { ThemeContext } from "../_providers/theme-provider";
 import { useContext } from "react";
-import { themeGen } from "../_utils";
 import Link from "next/link";
 import Image from "next/image";
 import { FullCategory } from "../_types";
@@ -15,19 +14,13 @@ export default function CategoryTile(props: CategoryTileProps) {
   const { appTheme } = useContext(ThemeContext);
   return (
     <div
-      className={`${themeGen(
-        appTheme
-      )} border-2 cursor-pointer  rounded-lg p-4 h-72 gap-2`}
+      className={`bg-${appTheme}-containerBg text-${appTheme}-text border-${appTheme}-border border-2 cursor-pointer  rounded-lg p-4 h-72 gap-2`}
     >
       <Link
         className="h-full w-full flex flex-col items-center gap-2"
         href={`/categories/${id}`}
       >
-        <div
-          className={`${
-            appTheme === "Classic" ? "bg-yellow" : "bg-green"
-          } h-3/4 w-3/4 rounded-lg`}
-        >
+        <div className={`bg-${appTheme}-text h-3/4 w-3/4 rounded-lg`}>
           <Image
             src={imageUrl}
             alt="imageUrl"

--- a/src/app/_components/dropDown.tsx
+++ b/src/app/_components/dropDown.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { useState, useContext } from "react";
+import chevDown from "../../../public/icons/chevdown.svg";
+import chevUp from "../../../public/icons/chevup.svg";
+import Image from "next/image";
+import { getFilter } from "../_utils";
+import { ThemeContext } from "../_providers/theme-provider";
+
+type DropdownProps = {
+  title: string;
+  options?: {
+    title: string;
+    setter: () => void;
+  }[];
+};
+
+export default function Dropdown(props: DropdownProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const { appTheme } = useContext(ThemeContext);
+  const { title, options } = props;
+
+  const iconStyle = {
+    filter: getFilter(appTheme),
+  };
+
+  const changeTheme = (setter: () => void) => {
+    setter();
+    setIsOpen(false);
+  };
+
+  const mouseOut = () => {
+    if (isOpen) {
+      setIsOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="cursor-pointer flex flex-row gap-2 relative"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <div className="cursor-pointer">{title}</div>
+        <Image
+          src={isOpen ? chevUp : chevDown}
+          alt="chev"
+          width={20}
+          height={20}
+          style={iconStyle}
+        />
+      </div>
+      {isOpen && (
+        <div
+          className={`mt-2 w-36 rounded-lg absolute h-auto border-2 bg-${appTheme}-containerBg border-${appTheme}-border`}
+          onMouseLeave={() => mouseOut()}
+        >
+          {options?.map((o, idx) => (
+            <div
+              key={idx}
+              onClick={() => changeTheme(o.setter)}
+              className={`flex flex-row p-4 items-center hover:bg-${appTheme}-bodyHover rounded-lg cursor-pointer`}
+            >
+              {o.title}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { ThemeContext } from "../_providers/theme-provider";
 import { useContext, useState } from "react";
 import HeaderMenu from "./headerMenu";
-import { themeGen } from "../_utils";
 import Image from "next/image";
 import accountIcon from "../../../public/icons/account.png";
 import cartIcon from "../../../public/icons/cart_png.png";
@@ -13,9 +12,10 @@ export default function Header() {
   const [showDrop, setShowDrop] = useState(false);
 
   const getFilter = () => {
-    if (appTheme === "Classic") {
+    if (appTheme === "classic") {
       return "invert(86%) sepia(21%) saturate(3341%) hue-rotate(360deg) brightness(105%) contrast(101%)";
-    } else {
+    }
+    if (appTheme === "dark") {
       return "invert(44%) sepia(97%) saturate(749%) hue-rotate(88deg) brightness(99%) contrast(104%)";
     }
   };
@@ -27,7 +27,7 @@ export default function Header() {
   return (
     <span
       className={`h-16 flex items-center px-4 border-b-2 z-10 absolute w-full
-    ${themeGen(appTheme)}
+    bg-${appTheme}-containerBg border-${appTheme}-border text-${appTheme}-text
     `}
     >
       <div

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -2,36 +2,46 @@
 import React from "react";
 import { ThemeContext } from "../_providers/theme-provider";
 import { useContext, useState } from "react";
-import HeaderMenu from "./headerMenu";
+import { HeaderMenu, Dropdown } from ".";
 import Image from "next/image";
+import { getFilter } from "../_utils";
 import accountIcon from "../../../public/icons/account.png";
 import cartIcon from "../../../public/icons/cart_png.png";
 
 export default function Header() {
-  const { appTheme } = useContext(ThemeContext);
+  const { appTheme, setAppTheme } = useContext(ThemeContext);
   const [showDrop, setShowDrop] = useState(false);
 
-  const getFilter = () => {
-    if (appTheme === "classic") {
-      return "invert(86%) sepia(21%) saturate(3341%) hue-rotate(360deg) brightness(105%) contrast(101%)";
-    }
-    if (appTheme === "dark") {
-      return "invert(44%) sepia(97%) saturate(749%) hue-rotate(88deg) brightness(99%) contrast(104%)";
-    }
+  const iconStyle = {
+    filter: getFilter(appTheme),
   };
 
-  const iconStyle = {
-    filter: getFilter(),
-  };
+  const themeOptions = [
+    {
+      title: "Classic",
+      setter: () => setAppTheme("classic"),
+    },
+    {
+      title: "Light",
+      setter: () => setAppTheme("light"),
+    },
+    {
+      title: "Dark",
+      setter: () => setAppTheme("dark"),
+    },
+  ];
 
   return (
     <span
       className={`h-16 flex items-center px-4 border-b-2 z-10 absolute w-full
-    bg-${appTheme}-containerBg border-${appTheme}-border text-${appTheme}-text
+    bg-${appTheme}-containerBg border-${appTheme}-border text-${appTheme}-text gap-10
     `}
     >
+      <div className="ml-auto">
+        <Dropdown title={"Site Theme"} options={themeOptions} />
+      </div>
       <div
-        className="ml-auto cursor-pointer"
+        className="cursor-pointer"
         onClick={() => console.log("coming soon")}
       >
         <Image
@@ -42,10 +52,7 @@ export default function Header() {
           style={iconStyle}
         />
       </div>
-      <div
-        className="ml-6 cursor-pointer"
-        onClick={() => setShowDrop(!showDrop)}
-      >
+      <div className="cursor-pointer" onClick={() => setShowDrop(!showDrop)}>
         <Image
           src={accountIcon}
           height={24}

--- a/src/app/_components/headerMenu.tsx
+++ b/src/app/_components/headerMenu.tsx
@@ -3,8 +3,6 @@ import React from "react";
 import { ThemeContext } from "../_providers/theme-provider";
 import { useContext } from "react";
 import { Dispatch, SetStateAction } from "react";
-import { themeGen } from "../_utils";
-import { ToggleSwitch } from "./index";
 
 type HeaderMenuProps = {
   setShowDrop: Dispatch<SetStateAction<boolean>>;
@@ -16,18 +14,10 @@ export default function HeaderMenu(props: HeaderMenuProps) {
 
   return (
     <div
-      className={`flex flex-row  w-[225px] border-2 rounded-md py-4 ${themeGen(
-        appTheme
-      )}`}
+      className={`flex flex-row  w-[225px] border-2 rounded-md py-4 text-${appTheme}-text border-${appTheme}-border bg-${appTheme}-bodyBg`}
       onMouseLeave={() => setShowDrop(false)}
     >
-      <div className="flex flex-row gap-2 px-2 min-w-[150px]">
-        {appTheme} Theme
-      </div>
-      <div>
-        Under Construction
-        {/* <ToggleSwitch /> */}
-      </div>
+      <div>Under Construction</div>
     </div>
   );
 }

--- a/src/app/_components/index.tsx
+++ b/src/app/_components/index.tsx
@@ -14,6 +14,7 @@ import ToggleSwitch from "./toggleSwitch";
 import ProductGrid from "./productGrid";
 import ProductList from "./productList";
 import ProductListItem from "./productListItem";
+import Dropdown from "./dropDown";
 
 export {
   CategoryList,
@@ -32,4 +33,5 @@ export {
   ProductGrid,
   ProductList,
   ProductListItem,
+  Dropdown,
 };

--- a/src/app/_components/productContainer.tsx
+++ b/src/app/_components/productContainer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { themeGen, pagePadding } from "../_utils";
+import { pagePadding } from "../_utils";
 import { ThemeContext } from "../_providers/theme-provider";
 import { useContext, useState } from "react";
 import {
@@ -34,9 +34,7 @@ export default function ProductContainer(props: ProdcutContainerProps) {
 
   return (
     <div
-      className={`${themeGen(
-        appTheme
-      )} ${pagePadding()} min-h-[calc(100vh-4rem)]`}
+      className={`text-${appTheme}-text bg-${appTheme}-bodyBg border-${appTheme}-border ${pagePadding()} min-h-[calc(100vh-4rem)]`}
     >
       {products.length > 0 ? (
         <div className={`mb-4 flex flex-col`}>

--- a/src/app/_components/productDisplay.tsx
+++ b/src/app/_components/productDisplay.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { FullProduct } from "../_types";
-import { pagePadding, themeGen, currencyGen } from "../_utils";
+import { pagePadding, currencyGen } from "../_utils";
 import { useContext } from "react";
 import { ThemeContext } from "../_providers/theme-provider";
 import Image from "next/image";
@@ -17,9 +17,7 @@ export default function ProductDisplay(props: ProductDisplayProps) {
   const { appTheme } = useContext(ThemeContext);
   return (
     <div
-      className={`${pagePadding()} ${themeGen(
-        appTheme
-      )}  min-h-[calc(100vh-4rem)] gap-2 flex flex-col`}
+      className={`${pagePadding()} text-${appTheme}-text border-${appTheme}-border bg-${appTheme}-bodyBg min-h-[calc(100vh-4rem)] gap-2 flex flex-col`}
     >
       <div className={`flex flex-row gap-32 mb-4 pt-8 `}>
         <div className={`w-1/3 h-auto border-2 border-red rounded-lg`}>

--- a/src/app/_components/productGrid.tsx
+++ b/src/app/_components/productGrid.tsx
@@ -11,7 +11,7 @@ export default function ProductGrid(props: ProductGridProps) {
   const { products, catId } = props;
   return (
     <div
-      className={`grid grid-cols-3 text-xl gap-6 gap-y-8 grid-auto-rows pr-6`}
+      className={`grid grid-cols-3 text-xl gap-10 gap-y-8 grid-auto-rows pr-6`}
     >
       {products.map((product, idx) => (
         <div key={idx}>

--- a/src/app/_components/productListItem.tsx
+++ b/src/app/_components/productListItem.tsx
@@ -1,6 +1,6 @@
 import { FullProduct } from "../_types";
 import Link from "next/link";
-import { themeGen, currencyGen } from "../_utils";
+import { currencyGen } from "../_utils";
 import { useContext } from "react";
 import { ThemeContext } from "../_providers/theme-provider";
 

--- a/src/app/_components/productTile.tsx
+++ b/src/app/_components/productTile.tsx
@@ -1,6 +1,6 @@
 import { FullProduct } from "../_types";
 import Link from "next/link";
-import { themeGen, currencyGen } from "../_utils";
+import { currencyGen } from "../_utils";
 import { useContext } from "react";
 import { ThemeContext } from "../_providers/theme-provider";
 
@@ -15,16 +15,14 @@ export default function ProductTile(props: ProductTileProps) {
   const { appTheme } = useContext(ThemeContext);
 
   return (
-    <div className={`${themeGen(appTheme)} border-2 rounded-lg p-4 h-72`}>
+    <div
+      className={`bg-${appTheme}-containerBg text-${appTheme}-text border-${appTheme}-border border-2 rounded-lg p-4 h-72`}
+    >
       <Link
         href={catId ? `/categories/${catId}/${id}` : `/products/${id}`}
         className={`flex flex-col items-center h-full w-full`}
       >
-        <div
-          className={`${
-            appTheme === "Classic" ? "bg-yellow" : "bg-green"
-          } h-3/4 w-3/4 rounded-lg mb-2`}
-        />
+        <div className={`bg-${appTheme}-text h-3/4 w-3/4 rounded-lg my-2`} />
         <div className="text-lg">{name}</div>
         <div className="text-base">
           {currencyGen(currency)}

--- a/src/app/_components/sideBar.tsx
+++ b/src/app/_components/sideBar.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { ThemeContext } from "../_providers/theme-provider";
 import { useContext } from "react";
 import Link from "next/link";
-import { themeGen, hoverGen } from "../_utils";
 import { lobsterFont } from "../fonts";
 
 export default function Sidebar() {
@@ -11,33 +10,33 @@ export default function Sidebar() {
 
   return (
     <div
-      className={`${
-        lobsterFont.className
-      } flex flex-col gap-6 -mt-[2px] h-full pt-10 items-center border-r-2 text-xl
-      ${themeGen(appTheme)}`}
+      className={`${lobsterFont.className} flex flex-col gap-6 -mt-[2px] h-full pt-10 items-center border-r-2 text-xl
+      bg-${appTheme}-containerBg text-${appTheme}-text border-${appTheme}-border`}
     >
       <Link href="/featured">
-        <div className={`${hoverGen(appTheme)} rounded-md p-2 px-4`}>
+        <div className={`hover:bg-${appTheme}-bodyHover rounded-md p-2 px-4`}>
           Featured Products
         </div>
       </Link>
       <Link href="/products">
-        <div className={`${hoverGen(appTheme)} rounded-md p-2 px-4`}>
+        <div className={`hover:bg-${appTheme}-bodyHover rounded-md p-2 px-4`}>
           All Products
         </div>
       </Link>
       <Link href="/categories">
-        <div className={`${hoverGen(appTheme)} rounded-md p-2 px-4`}>
+        <div className={`hover:bg-${appTheme}-bodyHover rounded-md p-2 px-4`}>
           Categories
         </div>
       </Link>
       <Link href="/adminPanel">
-        <div className={`${hoverGen(appTheme)} rounded-md p-2 px-4`}>
+        <div className={`hover:bg-${appTheme}-bodyHover rounded-md p-2 px-4`}>
           Admin Panel
         </div>
       </Link>
       <Link href="/about">
-        <div className={`${hoverGen(appTheme)} rounded-md p-2 px-4`}>About</div>
+        <div className={`hover:bg-${appTheme}-bodyHover rounded-md p-2 px-4`}>
+          About
+        </div>
       </Link>
     </div>
   );

--- a/src/app/_components/sidebarCap.tsx
+++ b/src/app/_components/sidebarCap.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { ThemeContext } from "../_providers/theme-provider";
 import { useContext } from "react";
-import { themeGen } from "../_utils";
 import Link from "next/link";
 import { lobsterFont } from "../fonts";
 import { Logo } from "./index";
@@ -13,9 +12,7 @@ export default function SidebarCap() {
   return (
     <Link href="/">
       <div
-        className={`min-h-16 max-h-16 flex flex-col items-center justify-center ${themeGen(
-          appTheme
-        )} ${lobsterFont.className}`}
+        className={`min-h-16 max-h-16 flex flex-col items-center justify-center text-${appTheme}-text bg-${appTheme}-containerBg border-${appTheme}-border ${lobsterFont.className}`}
       >
         <Logo size={"small"} />
       </div>

--- a/src/app/_components/toggleSwitch.tsx
+++ b/src/app/_components/toggleSwitch.tsx
@@ -10,15 +10,6 @@ export default function ToggleSwitch(props: ToggleSwitchProps) {
   const { state, setState } = props;
   const { appTheme } = useContext(ThemeContext);
 
-  const getStyles = () => {
-    if (appTheme === "Classic") {
-      return `bg-navy before:bg-yellow`;
-    }
-    if (appTheme === "Dark") {
-      return `bg-charcoal before:bg-green`;
-    }
-  };
-
   return (
     <label className="relative inline-block w-[60px] height-[34px]">
       <input
@@ -27,15 +18,10 @@ export default function ToggleSwitch(props: ToggleSwitchProps) {
         onChange={() => setState(!state)}
       />
       <span
-        className={`block h-[24px] bg-slate-700 absolute cursor-pointer top-0 left-0 right-0 bottom-0 transition duration-500 rounded-xl 
+        className={`block h-[24px] absolute cursor-pointer top-0 left-0 right-0 bottom-0 transition duration-500 rounded-xl 
     before:block before:rounded-xl before:absolute before:h-[24px] before:w-[24px] before:left-[4px] before:duration-500 
-     before:peer-checked:translate-x-[24px] ${getStyles()}`}
+     before:peer-checked:translate-x-[24px] bg-${appTheme}-bodyHover before:bg-${appTheme}-text`}
       />
     </label>
   );
 }
-
-// before:peer-checked:bg-yellow
-// peer-checked:bg-newNavy
-// bg-charcoal
-// before:bg-green

--- a/src/app/_providers/theme-provider.tsx
+++ b/src/app/_providers/theme-provider.tsx
@@ -8,7 +8,7 @@ interface ThemeContextType {
 }
 
 export const ThemeContext = createContext<ThemeContextType>({
-  appTheme: "Classic",
+  appTheme: "classic",
   setAppTheme: () => null,
 });
 
@@ -17,7 +17,7 @@ interface Props {
 }
 
 export const ThemeProvider: React.FC<Props> = ({ children }) => {
-  const [appTheme, setAppTheme] = useState("Classic");
+  const [appTheme, setAppTheme] = useState("classic");
   const value = {
     appTheme,
     setAppTheme,

--- a/src/app/_utils/index.tsx
+++ b/src/app/_utils/index.tsx
@@ -7,10 +7,10 @@ export const logoTextGen = (appTheme: string, size: string) => {
   if (appTheme === "classic" && size === "small") {
     return `font-outline-1 text-yellow ${small}`;
   }
-  if (appTheme === "Dark" && size === "large") {
+  if (appTheme === "dark" && size === "large") {
     return `font-outline-3 text-black bg-black ${large}`;
   }
-  if (appTheme === "Dark" && size === "small") {
+  if (appTheme === "dark" && size === "small") {
     return `font-outline-4 text-green bg-black ${small}`;
   }
 };
@@ -24,10 +24,10 @@ export const logoLineGen = (appTheme: string, size: string) => {
   if (appTheme === "classic" && size === "small") {
     return `bg-yellow border-red ${small}`;
   }
-  if (appTheme === "Dark" && size === "large") {
+  if (appTheme === "dark" && size === "large") {
     return `bg-black border-green ${large}`;
   }
-  if (appTheme === "Dark" && size === "small") {
+  if (appTheme === "dark" && size === "small") {
     return `bg-black border-green ${small}`;
   }
 };
@@ -40,4 +40,13 @@ export const currencyGen = (currency: string) => {
   if (currency === "USD") {
     return "$";
   } else return "R";
+};
+
+export const getFilter = (appTheme: string) => {
+  if (appTheme === "classic") {
+    return "invert(86%) sepia(21%) saturate(3341%) hue-rotate(360deg) brightness(105%) contrast(101%)";
+  }
+  if (appTheme === "dark") {
+    return "invert(44%) sepia(97%) saturate(749%) hue-rotate(88deg) brightness(99%) contrast(104%)";
+  }
 };

--- a/src/app/_utils/index.tsx
+++ b/src/app/_utils/index.tsx
@@ -1,26 +1,10 @@
-export const themeGen = (appTheme: string) => {
-  if (appTheme === "Classic") {
-    return "bg-newNavy text-yellow border-red";
-  } else {
-    return "bg-black text-green border-green";
-  }
-};
-
-export const hoverGen = (appTheme: string) => {
-  if (appTheme === "Classic") {
-    return "hover:bg-navy";
-  } else {
-    return "hover:bg-charcoal";
-  }
-};
-
 export const logoTextGen = (appTheme: string, size: string) => {
   const large = "text-7xl pt-[20%]";
   const small = "text-4xl pt-1";
-  if (appTheme === "Classic" && size === "large") {
+  if (appTheme === "classic" && size === "large") {
     return `font-outline-2 text-red bg-navy ${large}`;
   }
-  if (appTheme === "Classic" && size === "small") {
+  if (appTheme === "classic" && size === "small") {
     return `font-outline-1 text-yellow ${small}`;
   }
   if (appTheme === "Dark" && size === "large") {
@@ -34,10 +18,10 @@ export const logoTextGen = (appTheme: string, size: string) => {
 export const logoLineGen = (appTheme: string, size: string) => {
   const large = "h-[24px] w-1/4 mt-3 border-2";
   const small = "h-[6px] w-1/2 mt-1 border";
-  if (appTheme === "Classic" && size === "large") {
+  if (appTheme === "classic" && size === "large") {
     return `bg-red border-yellow ${large}`;
   }
-  if (appTheme === "Classic" && size === "small") {
+  if (appTheme === "classic" && size === "small") {
     return `bg-yellow border-red ${small}`;
   }
   if (appTheme === "Dark" && size === "large") {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,20 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
+        dark: {
+          border: "#03c51d",
+          text: "#03c51d",
+          containerBg: "#0000",
+          bodyBg: "#0000",
+          bodyHover: "#363636",
+        },
+        classic: {
+          border: "#cd0909",
+          text: "#ffdd00",
+          containerBg: "#3f5577",
+          bodyBg: "#33435B",
+          bodyHover: "#33435B",
+        },
         red: "#cd0909",
         yellow: "#ffdd00",
         green: "#03c51d",
@@ -19,5 +33,22 @@ const config: Config = {
     },
   },
   plugins: [],
+  safelist: [
+    {
+      pattern:
+        /(bg|text|border)-light-(border|text|containerBg|bodyBg|bodyHover)/,
+      variants: ["before", "hover"],
+    },
+    {
+      pattern:
+        /(bg|text|border)-classic-(border|text|containerBg|bodyBg|bodyHover)/,
+      variants: ["before", "hover"],
+    },
+    {
+      pattern:
+        /(bg|text|border)-dark-(border|text|containerBg|bodyBg|bodyHover)/,
+      variants: ["before", "hover"],
+    },
+  ],
 };
 export default config;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,8 +11,8 @@ const config: Config = {
         dark: {
           border: "#03c51d",
           text: "#03c51d",
-          containerBg: "#0000",
-          bodyBg: "#0000",
+          containerBg: "#000000",
+          bodyBg: "#000000",
           bodyHover: "#363636",
         },
         classic: {


### PR DESCRIPTION
- Extend colors and change color names so they can work better with multiple themes, "yellow" and "green" are now text-`themeName`-text, so that when the theme name changes, the only thing that needs to change is the theme name within the class.  This makes it easier to have more than 2 themes, and to recall which values are used where.  This change was ultimately made because I wanted to add a third more traditional 'light' theme, without adding more ifs to the themeGen or change it into a lengthy switch statement.  In the end this code is cleaner and more easily extended.
- As such, both themeGen and hoverGen utils have been removed
- Update tailwind.config.ts to support new theme styles, and to support static generated classes
- Update padding on category and product grids
- Create dropdown component
- Add dropdown component to header for changing theme, update spacing of items within header
- Clean up areas where styles were determined by old theme style still, but not directly by themeGen or hoverGen