### PR TITLE
Feature/suspense boundaries

### DIFF
--- a/src/app/_components/categoryList.tsx
+++ b/src/app/_components/categoryList.tsx
@@ -1,8 +1,5 @@
 "use client";
-import { ThemeContext } from "../_providers/index";
-import { useContext } from "react";
-import { pagePadding } from "../_utils";
-import { CategoryTile, ListHeader } from "./index";
+import { CategoryTile } from "./index";
 import { FullCategory } from "../_types";
 
 type CategoryListProps = {
@@ -11,31 +8,25 @@ type CategoryListProps = {
 
 export default function CategoryList(props: CategoryListProps) {
   const { categories } = props;
-  const { appTheme } = useContext(ThemeContext);
   return (
     <div
-      className={`flex flex-col bg-${appTheme}-bodyBg text-${appTheme}-text border-${appTheme}-border ${pagePadding()} min-h-screen`}
+      className={`grid grid-cols-3 text-xl gap-10 gap-y-8 grid-auto-rows mt-4`}
     >
-      <ListHeader title={"Product Categories"} />
-      <div
-        className={`grid grid-cols-3 text-xl gap-10 gap-y-8 grid-auto-rows mt-4`}
-      >
-        {categories
-          .sort((a, b) => {
-            const nameA = a.name.toUpperCase();
-            const nameB = b.name.toUpperCase();
-            if (nameA < nameB) {
-              return -1;
-            }
-            if (nameA > nameB) {
-              return 1;
-            }
-            return 0;
-          })
-          .map((category, idx) => (
-            <CategoryTile key={idx} category={category} />
-          ))}
-      </div>
+      {categories
+        .sort((a, b) => {
+          const nameA = a.name.toUpperCase();
+          const nameB = b.name.toUpperCase();
+          if (nameA < nameB) {
+            return -1;
+          }
+          if (nameA > nameB) {
+            return 1;
+          }
+          return 0;
+        })
+        .map((category, idx) => (
+          <CategoryTile key={idx} category={category} />
+        ))}
     </div>
   );
 }

--- a/src/app/_components/index.tsx
+++ b/src/app/_components/index.tsx
@@ -18,6 +18,8 @@ import Dropdown from "./dropDown";
 import Button from "./button";
 import IndicatorBanner from "./indicatorBanner";
 import IndicatorCircle from "./indicatorCircle";
+import PageWrapper from "./pageWrapper";
+import LoadingSpinner from "./loadingSpinner";
 
 export {
   CategoryList,
@@ -40,4 +42,6 @@ export {
   Button,
   IndicatorBanner,
   IndicatorCircle,
+  PageWrapper,
+  LoadingSpinner,
 };

--- a/src/app/_components/loadingSpinner.tsx
+++ b/src/app/_components/loadingSpinner.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { ThemeContext } from "../_providers/index";
+import { useContext } from "react";
+
+export default function LoadingSpinner() {
+  const { appTheme } = useContext(ThemeContext);
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center h-screen bg-${appTheme}-bodyBg`}
+    >
+      <div
+        className={`animate-spin-slow rounded-full h-16 w-16 border-t-4 border-${appTheme}-text border-solid`}
+      ></div>
+    </div>
+  );
+}

--- a/src/app/_components/pageWrapper.tsx
+++ b/src/app/_components/pageWrapper.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { ThemeContext } from "../_providers/index";
+import { ReactElement, useContext } from "react";
+type PageWrapperProps = {
+  children: ReactElement | ReactElement[];
+};
+
+export default function PageWrapper(props: PageWrapperProps) {
+  const { children } = props;
+  const { appTheme } = useContext(ThemeContext);
+  return (
+    <div
+      className={`text-${appTheme}-text border-${appTheme}-border bg-${appTheme}-bodyBg px-8 pt-6 pb-4 pl-10 min-h-[calc(100vh-4rem)]`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/app/_components/productContainer.tsx
+++ b/src/app/_components/productContainer.tsx
@@ -1,66 +1,31 @@
 "use client";
-import { pagePadding } from "../_utils";
-import { ThemeContext } from "../_providers/index";
-import { useContext, useState } from "react";
-import {
-  ListHeader,
-  SearchBar,
-  ProductGrid,
-  ToggleSwitch,
-  ProductList,
-} from "./index";
+
+import { useState } from "react";
+import { ProductGrid, ToggleSwitch, ProductList } from "./index";
 import { FullProduct } from "../_types";
 
 type ProdcutContainerProps = {
   products: FullProduct[];
-  allProducts?: boolean;
-  featuredProducts?: boolean;
   catId?: string;
 };
 
 export default function ProductContainer(props: ProdcutContainerProps) {
-  const { products, allProducts, catId, featuredProducts } = props;
-  const { appTheme } = useContext(ThemeContext);
+  const { products, catId } = props;
   const [gridView, setGridView] = useState(true);
 
-  const getTitle = () => {
-    if (allProducts) {
-      return "All Products";
-    }
-    if (featuredProducts) {
-      return "Featured Products";
-    } else return `${products[0].category?.name}`;
-  };
-
   return (
-    <div
-      className={`text-${appTheme}-text bg-${appTheme}-bodyBg border-${appTheme}-border ${pagePadding()} min-h-[calc(100vh-4rem)]`}
-    >
-      {products.length > 0 ? (
-        <div className={`mb-4 flex flex-col`}>
-          <div className="flex flex-row items-center mb-2">
-            <ListHeader title={getTitle()} />
-            {!featuredProducts && (
-              <div className="ml-auto w-1/3">
-                <SearchBar />
-              </div>
-            )}
-          </div>
-          <div className="ml-auto mr-6">
-            <div className="flex flex-row gap-2">
-              {gridView ? "Grid View" : "List View"}
-              <ToggleSwitch state={gridView} setState={setGridView} />
-            </div>
-          </div>
+    <>
+      <div className=" mr-6 mb-4">
+        <div className="flex flex-row gap-2 w-full justify-end">
+          {gridView ? "Grid View" : "List View"}
+          <ToggleSwitch state={gridView} setState={setGridView} />
         </div>
-      ) : (
-        <ListHeader title={"No Products"} />
-      )}
+      </div>
       {gridView ? (
         <ProductGrid products={products} catId={catId} />
       ) : (
         <ProductList products={products} catId={catId} />
       )}
-    </div>
+    </>
   );
 }

--- a/src/app/_components/productContainer.tsx
+++ b/src/app/_components/productContainer.tsx
@@ -4,12 +4,12 @@ import { useState } from "react";
 import { ProductGrid, ToggleSwitch, ProductList } from "./index";
 import { FullProduct } from "../_types";
 
-type ProdcutContainerProps = {
+type ProductContainerProps = {
   products: FullProduct[];
   catId?: string;
 };
 
-export default function ProductContainer(props: ProdcutContainerProps) {
+export default function ProductContainer(props: ProductContainerProps) {
   const { products, catId } = props;
   const [gridView, setGridView] = useState(true);
 

--- a/src/app/_components/productDisplay.tsx
+++ b/src/app/_components/productDisplay.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { FullProduct } from "../_types";
-import { pagePadding, currencyGen } from "../_utils";
+import { currencyGen } from "../_utils";
 import { useContext } from "react";
 import { ThemeContext, CartContext, BannerContext } from "../_providers/index";
 import { Button } from ".";
@@ -77,9 +77,7 @@ export default function ProductDisplay(props: ProductDisplayProps) {
   };
 
   return (
-    <div
-      className={`${pagePadding()} text-${appTheme}-text border-${appTheme}-border bg-${appTheme}-bodyBg min-h-[calc(100vh-4rem)] gap-2 flex flex-col pl-16`}
-    >
+    <div className={`gap-2 flex flex-col pl-16`}>
       <div className={`flex flex-row gap-36 mb-4 pt-8`}>
         <div
           className={`w-1/3 h-2/3 border-2 border-${appTheme}-border rounded-lg ml-2`}

--- a/src/app/_components/sideBar.tsx
+++ b/src/app/_components/sideBar.tsx
@@ -13,38 +13,24 @@ export default function Sidebar() {
       className={`${lobsterFont.className} flex flex-col gap-6 -mt-[2px] h-full pt-10 items-center border-r-2 text-xl
       bg-${appTheme}-containerBg text-${appTheme}-text border-${appTheme}-border`}
     >
-      <Link href="/featured">
-        <div
-          className={`hover:bg-${appTheme}-containerHover rounded-md p-2 px-4`}
-        >
-          Featured Products
+      <Link href="/categories">
+        <div className={`hover:bg-${appTheme}-bodyBg rounded-md p-2 px-4`}>
+          Shop By Category
         </div>
       </Link>
       <Link href="/products">
-        <div
-          className={`hover:bg-${appTheme}-containerHover rounded-md p-2 px-4`}
-        >
+        <div className={`hover:bg-${appTheme}-bodyBg rounded-md p-2 px-4`}>
           All Products
         </div>
       </Link>
-      <Link href="/categories">
-        <div
-          className={`hover:bg-${appTheme}-containerHover rounded-md p-2 px-4`}
-        >
-          Categories
-        </div>
-      </Link>
+
       <Link href="/adminPanel">
-        <div
-          className={`hover:bg-${appTheme}-containerHover rounded-md p-2 px-4`}
-        >
+        <div className={`hover:bg-${appTheme}-bodyBg rounded-md p-2 px-4`}>
           Admin Panel
         </div>
       </Link>
       <Link href="/about">
-        <div
-          className={`hover:bg-${appTheme}-containerHover rounded-md p-2 px-4`}
-        >
+        <div className={`hover:bg-${appTheme}-bodyBg rounded-md p-2 px-4`}>
           About
         </div>
       </Link>

--- a/src/app/_utils/index.tsx
+++ b/src/app/_utils/index.tsx
@@ -32,10 +32,6 @@ export const logoLineGen = (appTheme: string, size: string) => {
   }
 };
 
-export const pagePadding = () => {
-  return `px-8 pt-6 pb-4 pl-10`;
-};
-
 export const currencyGen = (currency: string) => {
   if (currency === "USD") {
     return "$";

--- a/src/app/categories/[id]/[prodId]/page.tsx
+++ b/src/app/categories/[id]/[prodId]/page.tsx
@@ -1,12 +1,15 @@
 import { getProductById } from "@/app/_utils/serverutils";
-import { ProductDisplay } from "@/app/_components";
+import { ProductDisplay, LoadingSpinner } from "@/app/_components";
+import { Suspense } from "react";
 
 export default async function Page({ params }: { params: { prodId: string } }) {
   const { prodId } = params;
   const product = await getProductById(prodId);
   return (
     <>
-      <ProductDisplay product={product} />
+      <Suspense fallback={<LoadingSpinner />}>
+        <ProductDisplay product={product} />
+      </Suspense>
     </>
   );
 }

--- a/src/app/categories/[id]/[prodId]/page.tsx
+++ b/src/app/categories/[id]/[prodId]/page.tsx
@@ -1,15 +1,15 @@
 import { getProductById } from "@/app/_utils/serverutils";
-import { ProductDisplay, LoadingSpinner } from "@/app/_components";
+import { ProductDisplay, LoadingSpinner, PageWrapper } from "@/app/_components";
 import { Suspense } from "react";
 
 export default async function Page({ params }: { params: { prodId: string } }) {
   const { prodId } = params;
   const product = await getProductById(prodId);
   return (
-    <>
+    <PageWrapper>
       <Suspense fallback={<LoadingSpinner />}>
         <ProductDisplay product={product} />
       </Suspense>
-    </>
+    </PageWrapper>
   );
 }

--- a/src/app/categories/[id]/page.tsx
+++ b/src/app/categories/[id]/page.tsx
@@ -1,5 +1,12 @@
-import { ProductContainer } from "@/app/_components";
 import { getCategoryProducts } from "@/app/_utils/serverutils";
+import {
+  ListHeader,
+  SearchBar,
+  ProductContainer,
+  PageWrapper,
+  LoadingSpinner,
+} from "@/app/_components";
+import { Suspense } from "react";
 
 export default async function Page({
   params,
@@ -17,8 +24,23 @@ export default async function Page({
       })
     : [];
   return (
-    <>
-      <ProductContainer catId={id} products={filteredProducts} />
-    </>
+    <PageWrapper>
+      <div className="flex flex-row items-center mb-4">
+        <Suspense fallback={<LoadingSpinner />}>
+          <ListHeader
+            title={
+              products.length ? `${products[0].category.name}` : "No Products"
+            }
+          />
+
+          <div className="ml-auto w-1/3">
+            <SearchBar />
+          </div>
+        </Suspense>
+      </div>
+      <Suspense fallback={<LoadingSpinner />}>
+        <ProductContainer catId={id} products={filteredProducts} />
+      </Suspense>
+    </PageWrapper>
   );
 }

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,11 +1,22 @@
-import { CategoryList } from "../_components";
+import {
+  CategoryList,
+  PageWrapper,
+  ListHeader,
+  LoadingSpinner,
+} from "../_components";
 import { getCategories } from "../_utils/serverutils";
+import { Suspense } from "react";
 
 export default async function Categories() {
   const categories = await getCategories();
   return (
-    <>
-      <CategoryList categories={categories} />
-    </>
+    <PageWrapper>
+      <div className={`flex flex-col`}>
+        <ListHeader title={"Product Categories"} />
+        <Suspense fallback={<LoadingSpinner />}>
+          <CategoryList categories={categories} />
+        </Suspense>
+      </div>
+    </PageWrapper>
   );
 }

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -12,7 +12,9 @@ export default async function Categories() {
   return (
     <PageWrapper>
       <div className={`flex flex-col`}>
-        <ListHeader title={"Product Categories"} />
+        <div className="mb-2">
+          <ListHeader title={"Product Categories"} />
+        </div>
         <Suspense fallback={<LoadingSpinner />}>
           <CategoryList categories={categories} />
         </Suspense>

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -13,7 +13,7 @@ export default async function Categories() {
     <PageWrapper>
       <div className={`flex flex-col`}>
         <div className="mb-2">
-          <ListHeader title={"Product Categories"} />
+          <ListHeader title={"Shop by Category"} />
         </div>
         <Suspense fallback={<LoadingSpinner />}>
           <CategoryList categories={categories} />

--- a/src/app/featured/page.tsx
+++ b/src/app/featured/page.tsx
@@ -9,7 +9,6 @@ export default async function FeaturedProducts() {
         products={products.sort(
           (a, b) => Number(a.categoryId) - Number(b.categoryId)
         )}
-        featuredProducts
       />
     </div>
   );

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1,15 +1,15 @@
 import { getProductById } from "@/app/_utils/serverutils";
-import { ProductDisplay, LoadingSpinner } from "@/app/_components";
+import { ProductDisplay, LoadingSpinner, PageWrapper } from "@/app/_components";
 import { Suspense } from "react";
 
 export default async function Page({ params }: { params: { id: string } }) {
   const { id } = params;
   const product = await getProductById(id);
   return (
-    <>
+    <PageWrapper>
       <Suspense fallback={<LoadingSpinner />}>
         <ProductDisplay product={product} />
       </Suspense>
-    </>
+    </PageWrapper>
   );
 }

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1,12 +1,15 @@
 import { getProductById } from "@/app/_utils/serverutils";
-import { ProductDisplay } from "@/app/_components";
+import { ProductDisplay, LoadingSpinner } from "@/app/_components";
+import { Suspense } from "react";
 
 export default async function Page({ params }: { params: { id: string } }) {
   const { id } = params;
   const product = await getProductById(id);
   return (
     <>
-      <ProductDisplay product={product} />
+      <Suspense fallback={<LoadingSpinner />}>
+        <ProductDisplay product={product} />
+      </Suspense>
     </>
   );
 }

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,5 +1,12 @@
-import { ProductContainer } from "@/app/_components";
 import { getProducts } from "../_utils/serverutils";
+import {
+  ListHeader,
+  SearchBar,
+  ProductContainer,
+  PageWrapper,
+  LoadingSpinner,
+} from "@/app/_components";
+import { Suspense } from "react";
 
 export default async function AllProducts({
   searchParams,
@@ -13,14 +20,23 @@ export default async function AllProducts({
         return product.name.toLowerCase().includes(query.toLowerCase());
       })
     : [];
+
   return (
-    <>
-      <ProductContainer
-        products={filteredProducts.sort(
-          (a, b) => Number(a.categoryId) - Number(b.categoryId)
-        )}
-        allProducts
-      />
-    </>
+    <PageWrapper>
+      <div className="flex flex-row items-center mb-4">
+        <ListHeader title={"All Products"} />
+
+        <div className="ml-auto w-1/3">
+          <SearchBar />
+        </div>
+      </div>
+      <Suspense fallback={<LoadingSpinner />}>
+        <ProductContainer
+          products={filteredProducts.sort(
+            (a, b) => Number(a.categoryId) - Number(b.categoryId)
+          )}
+        />
+      </Suspense>
+    </PageWrapper>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,11 +22,20 @@ const config: Config = {
         classic: {
           border: "#cd0909",
           text: "#ffdd00",
-          containerBg: "#3f5577",
+          bodyBg: "#3f5577",
           containerHover: "#33435B",
-          bodyBg: "#1F2E47",
+          containerBg: "#1F2E47",
           seconadry: "#03c51d",
         },
+      },
+      keyframes: {
+        "spin-slow": {
+          "0%": { transform: "rotate(0deg)" },
+          "100%": { transform: "rotate(360deg)" },
+        },
+      },
+      animation: {
+        "spin-slow": "spin-slow 3s linear infinite",
       },
     },
   },


### PR DESCRIPTION
- Move many page elements out into page files, instead of all living in containers or lists
- Move page padding into PageWrapper instead of being generated
- Create loading spinner component
- Add suspense boundaries, although they will likely never show due to next cacheing
- Remove featured products link from sidebar, this page will be removed soon and featured products will instead display on the landing
- Swap background colors of classic theme, this looks better
- Fix spelling error on ProductContainerProps type
- Remove padding util function altogether