### PR TITLE
Feature/toggle sidebar

### DIFF
--- a/public/icons/barsdown.svg
+++ b/public/icons/barsdown.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M3 4.5h14.25M3 9h9.75M3 13.5h9.75m4.5-4.5v12m0 0-3.75-3.75M17.25 21 21 17.25" />
-</svg>

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -9,6 +9,7 @@ import {
   Cart,
   MobileMenu,
   ThemeMenu,
+  Sidebar,
 } from ".";
 import Image from "next/image";
 import { getFilter } from "../_utils";
@@ -22,7 +23,7 @@ import themeIcon from "../../../public/icons/theme.svg";
 import { useRouter, usePathname } from "next/navigation";
 
 export default function Header() {
-  const { appTheme } = useContext(ThemeContext);
+  const { appTheme, showSidebar, setShowSidebar } = useContext(ThemeContext);
   const { user } = useContext(UserContext);
   const { cart, wishlist, showCart, setShowCart } = useContext(CartContext);
   const [showAccount, setShowAccount] = useState(false);
@@ -49,13 +50,24 @@ export default function Header() {
   return (
     <div className="flex flex-col relative">
       <span
-        className={`h-16 flex items-center px-4 z-10 fixed w-[100%] sm:w-[87%]
-    bg-${appTheme}-containerBg text-${appTheme}-text gap-6 sm:gap-10 
+        className={`h-16 flex items-center px-4 z-10 fixed w-[100%] bg-${appTheme}-containerBg text-${appTheme}-text gap-6 sm:gap-10 
     `}
       >
         <div
           className={`sm:hidden cursor-pointer relative hover:bg-${appTheme}-bodyBg rounded-full p-2`}
           onClick={() => showMobMenu()}
+        >
+          <Image
+            src={showSidebar ? barsDown : bars}
+            height={24}
+            width={24}
+            alt="my orders Icon"
+            style={iconStyle}
+          />
+        </div>
+        <div
+          className={`hidden sm:flex cursor-pointer relative hover:bg-${appTheme}-bodyBg rounded-full p-2`}
+          onClick={() => setShowSidebar(!showSidebar)}
         >
           <Image
             src={showMobileMenu ? barsDown : bars}
@@ -145,6 +157,7 @@ export default function Header() {
           <AccountMenu setShowDrop={setShowAccount} />
         </div>
         <Cart />
+        <Sidebar />
       </span>
       <IndicatorBanner />
       {showMobileMenu && <MobileMenu />}

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -10,6 +10,7 @@ import {
   MobileMenu,
   ThemeMenu,
   Sidebar,
+  SidebarCap,
 } from ".";
 import Image from "next/image";
 import { getFilter } from "../_utils";
@@ -18,7 +19,6 @@ import cartIcon from "../../../public/icons/cart_png.png";
 import wishList from "../../../public/icons/wishlist.svg";
 import orderTruck from "../../../public/icons/truck.svg";
 import bars from "../../../public/icons/bars.svg";
-import barsDown from "../../../public/icons/barsdown.svg";
 import themeIcon from "../../../public/icons/theme.svg";
 import { useRouter, usePathname } from "next/navigation";
 
@@ -58,7 +58,7 @@ export default function Header() {
           onClick={() => showMobMenu()}
         >
           <Image
-            src={showSidebar ? barsDown : bars}
+            src={bars}
             height={24}
             width={24}
             alt="my orders Icon"
@@ -70,12 +70,15 @@ export default function Header() {
           onClick={() => setShowSidebar(!showSidebar)}
         >
           <Image
-            src={showMobileMenu ? barsDown : bars}
+            src={bars}
             height={24}
             width={24}
             alt="my orders Icon"
             style={iconStyle}
           />
+        </div>
+        <div className="hidden sm:flex relative right-6">
+          <SidebarCap />
         </div>
         <div
           className="cursor-pointer ml-auto"

--- a/src/app/_components/reactCarousel.tsx
+++ b/src/app/_components/reactCarousel.tsx
@@ -14,11 +14,11 @@ export default function ReactCarousel(props: CarouselProps) {
       items: 5,
     },
     desktop: {
-      breakpoint: { max: 3000, min: 1500 },
+      breakpoint: { max: 3000, min: 1200 },
       items: 4,
     },
     smdesktop: {
-      breakpoint: { max: 1500, min: 1024 },
+      breakpoint: { max: 1200, min: 1024 },
       items: 3,
     },
     tablet: {

--- a/src/app/_components/sideBar.tsx
+++ b/src/app/_components/sideBar.tsx
@@ -6,9 +6,9 @@ import Link from "next/link";
 import { robotoFont } from "../fonts";
 
 export default function Sidebar() {
-  const { appTheme, showSidebar } = useContext(ThemeContext);
+  const { appTheme, showSidebar, setShowSidebar } = useContext(ThemeContext);
   const getTranslate = () => {
-    if (showSidebar === false) {
+    if (showSidebar === true) {
       return `translate-x-full`;
     } else return null;
   };
@@ -16,30 +16,34 @@ export default function Sidebar() {
     <div
       className={`${
         robotoFont.className
-      } hidden sm:flex flex-col gap-6 -mt-[2px] pt-10 items-center
-      bg-${appTheme}-containerBg text-${appTheme}-text px-4 text-xs xl:text-xl lg:text-lg md:text-base sm:text-xs absolute h-[calc(100vh-4rem)] top-16 -left-1/4 w-1/4 transition duration-500 ${getTranslate()} `}
+      } hidden sm:flex flex-col gap-6 pt-10 items-center
+      bg-${appTheme}-containerBg text-${appTheme}-text px-4 text-xs xl:text-xl lg:text-lg md:text-base sm:text-xs absolute h-[calc(100vh-4rem)] top-16 -left-1/4 w-1/4 transition duration-500 ${getTranslate()} z-[10001]`}
     >
       <Link
         href="/categories"
         className={`min-w-full flex justify-center lg:text-nowrap hover:bg-${appTheme}-bodyBg rounded-md p-2`}
+        onClick={() => setShowSidebar(false)}
       >
         Categories
       </Link>
       <Link
         href="/products"
         className={`min-w-full flex justify-center hover:bg-${appTheme}-bodyBg rounded-md p-2 `}
+        onClick={() => setShowSidebar(false)}
       >
         All Products
       </Link>
       <Link
         href="/admin-panel"
         className={`min-w-full flex justify-center hover:bg-${appTheme}-bodyBg rounded-md p-2 `}
+        onClick={() => setShowSidebar(false)}
       >
         Admin
       </Link>
       <Link
         href="/about"
         className={`min-w-full flex justify-center hover:bg-${appTheme}-bodyBg rounded-md p-2 `}
+        onClick={() => setShowSidebar(false)}
       >
         About
       </Link>

--- a/src/app/_components/sideBar.tsx
+++ b/src/app/_components/sideBar.tsx
@@ -6,12 +6,18 @@ import Link from "next/link";
 import { robotoFont } from "../fonts";
 
 export default function Sidebar() {
-  const { appTheme } = useContext(ThemeContext);
-
+  const { appTheme, showSidebar } = useContext(ThemeContext);
+  const getTranslate = () => {
+    if (showSidebar === false) {
+      return `translate-x-full`;
+    } else return null;
+  };
   return (
     <div
-      className={`${robotoFont.className} flex flex-col gap-6 -mt-[2px] h-full pt-10 items-center
-      bg-${appTheme}-containerBg text-${appTheme}-text min-w-full px-4 text-xs xl:text-xl lg:text-lg md:text-base sm:text-xs`}
+      className={`${
+        robotoFont.className
+      } hidden sm:flex flex-col gap-6 -mt-[2px] pt-10 items-center
+      bg-${appTheme}-containerBg text-${appTheme}-text px-4 text-xs xl:text-xl lg:text-lg md:text-base sm:text-xs absolute h-[calc(100vh-4rem)] top-16 -left-1/4 w-1/4 transition duration-500 ${getTranslate()} `}
     >
       <Link
         href="/categories"

--- a/src/app/_components/sidebarCap.tsx
+++ b/src/app/_components/sidebarCap.tsx
@@ -1,33 +1,13 @@
 "use client";
 import React from "react";
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import Link from "next/link";
 import { lobsterFont } from "../fonts";
 import { Logo } from "./index";
-import { CleanWishlist, SafeUser } from "../_types";
-import { Session } from "next-auth";
-import { CartContext, ThemeContext, UserContext } from "../_providers/index";
+import { ThemeContext } from "../_providers/index";
 
-type SidebarCapProps = {
-  session: {
-    session: Session;
-    user: SafeUser;
-    cleanWishlist: CleanWishlist | null;
-  } | null;
-};
-
-export default function SidebarCap(props: SidebarCapProps) {
+export default function SidebarCap() {
   const { appTheme } = useContext(ThemeContext);
-  const { session } = props;
-  const { user, setUser } = useContext(UserContext);
-  const { setWishlist } = useContext(CartContext);
-
-  useEffect(() => {
-    if (session && session !== null) {
-      setUser(session.user);
-      setWishlist(session?.cleanWishlist?.wishlistItems || []);
-    }
-  }, [session]);
 
   return (
     <Link href="/">

--- a/src/app/_components/siteModal.tsx
+++ b/src/app/_components/siteModal.tsx
@@ -1,11 +1,37 @@
 "use client";
-import { useContext } from "react";
-import { ThemeContext, ModalContext } from "../_providers";
+import { useContext, useEffect } from "react";
+import {
+  ThemeContext,
+  ModalContext,
+  UserContext,
+  CartContext,
+} from "../_providers";
 import Image from "next/image";
-export default function SiteModal() {
+import { Session } from "next-auth";
+import { CleanWishlist, SafeUser } from "../_types";
+
+type SiteModalProps = {
+  session: {
+    session: Session;
+    user: SafeUser;
+    cleanWishlist: CleanWishlist | null;
+  } | null;
+};
+
+export default function SiteModal(props: SiteModalProps) {
+  const { session } = props;
   const { appTheme } = useContext(ThemeContext);
+  const { user, setUser } = useContext(UserContext);
+  const { setWishlist } = useContext(CartContext);
   const { showModal, setShowModal, modalType, modalContent } =
     useContext(ModalContext);
+
+  useEffect(() => {
+    if (session && session !== null) {
+      setUser(session.user);
+      setWishlist(session?.cleanWishlist?.wishlistItems || []);
+    }
+  }, [session]);
 
   const getModal = () => {
     switch (modalType) {

--- a/src/app/_providers/theme-provider.tsx
+++ b/src/app/_providers/theme-provider.tsx
@@ -1,15 +1,19 @@
 "use client";
 import React from "react";
 import { createContext, useState } from "react";
-
+import { Dispatch, SetStateAction } from "react";
 interface ThemeContextType {
   appTheme: string;
   setAppTheme: (appTheme: string) => void;
+  showSidebar: boolean;
+  setShowSidebar: Dispatch<SetStateAction<boolean>>;
 }
 
 export const ThemeContext = createContext<ThemeContextType>({
   appTheme: "classic",
   setAppTheme: () => null,
+  showSidebar: false,
+  setShowSidebar: () => null,
 });
 
 interface Props {
@@ -18,9 +22,12 @@ interface Props {
 
 export const ThemeProvider: React.FC<Props> = ({ children }) => {
   const [appTheme, setAppTheme] = useState("classic");
+  const [showSidebar, setShowSidebar] = useState(false);
   const value = {
     appTheme,
     setAppTheme,
+    showSidebar,
+    setShowSidebar,
   };
   return (
     <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>

--- a/src/app/_utils/index.tsx
+++ b/src/app/_utils/index.tsx
@@ -3,7 +3,7 @@ import { updateWishlist } from "./serverutils";
 
 export const logoTextGen = (appTheme: string, size: string) => {
   const large = "text-6xl";
-  const small = "text-4xl pt-1";
+  const small = "text-4xl";
   if (appTheme === "classic" && size === "large") {
     return `font-outline-2 text-${appTheme}-border bg-${appTheme}-bodyBg ${large}`;
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,10 @@
   }
 }
 
+.react-multiple-carousel__arrow--left {
+  z-index: 1 !important;
+}
+
 @layer base {
   .font-outline-1 {
     -webkit-text-stroke: 1px #cd0909;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,11 +42,7 @@ export default async function Layout({
             <CartProvider>
               <html lang="en">
                 <body className={`${robotoFont.className} flex flex-row`}>
-                  <div className="hidden w-[13%] h-screen sm:flex flex-col">
-                    <SidebarCap session={session} />
-                    <Sidebar />
-                  </div>
-                  <div className="w-[100%] sm:w-[87%] h-full max-h-screen overflow-y-auto overflow-x-hidden">
+                  <div className="w-[100%] h-full max-h-screen overflow-y-auto overflow-x-hidden">
                     {children}
                     <SiteModal />
                     <Analytics />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,7 @@ export default async function Layout({
                 <body className={`${robotoFont.className} flex flex-row`}>
                   <div className="w-[100%] h-full max-h-screen overflow-y-auto overflow-x-hidden">
                     {children}
-                    <SiteModal />
+                    <SiteModal session={session} />
                     <Analytics />
                     <SpeedInsights />
                   </div>


### PR DESCRIPTION
- Rework sidebar layout and header to make the left sidebar toggle instead of always showing
- Move user / wishlist set logic from sidebar cap into sitemodal
- Adjust logo to reflect positional change of sidebar cap, which now shows slightly to the right of the sidebar toggle, this component will likely be reworked/renamed in the future, perhaps it will only be the logo component
- Stop carousel arrow from showing above open sidebar
- Add sidebar toggle to theme context
- This was a decision I'd been mulling over for a while, so I decided to interrupt the dashboard development with this change once I'd made up my mind