### PR TITLE
fix appearance of mobile menu

### DIFF
--- a/src/app/_components/Header/index.tsx
+++ b/src/app/_components/Header/index.tsx
@@ -172,9 +172,9 @@ export default function Header() {
         </div>
         <Cart />
         <Sidebar toggleRef={sideBarToggleRef} />
+        {showMobileMenu && <MobileMenu />}
       </span>
       <IndicatorBanner />
-      {showMobileMenu && <MobileMenu />}
     </div>
   );
 }

--- a/src/app/_components/MobileMenu/index.tsx
+++ b/src/app/_components/MobileMenu/index.tsx
@@ -6,23 +6,23 @@ export default function MobileMenu() {
 
   return (
     <div
-      className={`sm:hidden sticky w-full flex flex-col bg-${appTheme}-bodyBg h-screen pt-20 px-4 gap-4`}
+      className={`sm:hidden absolute top-16 w-[95%] flex flex-col bg-${appTheme}-bodyBg h-screen pt-20 gap-4`}
     >
       <Link
         href="/categories"
-        className={`w-full border-2 border-${appTheme}-border rounded-lg h-16 flex items-center justify-center bg-${appTheme}-containerBg hover:bg-${appTheme}-bodyBg text-xl`}
+        className={`border-2 border-${appTheme}-border rounded-lg h-16 flex items-center justify-center bg-${appTheme}-containerBg hover:bg-${appTheme}-bodyBg text-xl text-${appTheme}-text`}
       >
         Categories
       </Link>
       <Link
         href="/products"
-        className={`w-full border-2 border-${appTheme}-border rounded-lg h-16 flex items-center justify-center bg-${appTheme}-containerBg hover:bg-${appTheme}-bodyBg text-xl`}
+        className={` border-2 border-${appTheme}-border rounded-lg h-16 flex items-center justify-center bg-${appTheme}-containerBg hover:bg-${appTheme}-bodyBg text-xl text-${appTheme}-text`}
       >
         Products
       </Link>
       <Link
         href="/admin-panel"
-        className={`w-full border-2 border-${appTheme}-border rounded-lg h-16 flex items-center justify-center bg-${appTheme}-containerBg hover:bg-${appTheme}-bodyBg text-xl`}
+        className={` border-2 border-${appTheme}-border rounded-lg h-16 flex items-center justify-center bg-${appTheme}-containerBg hover:bg-${appTheme}-bodyBg text-xl text-${appTheme}-text`}
       >
         Admin
       </Link>


### PR DESCRIPTION
- Mobile menu button text was not showing in dark mode
- Mobile Menu was sitting at the top of the page, not wherever the user opened it.